### PR TITLE
Revert "Allow default read_timeout to be overidden"

### DIFF
--- a/lib/roar/transport/net_http/request.rb
+++ b/lib/roar/transport/net_http/request.rb
@@ -12,11 +12,6 @@ module Roar
           @options = options
 
           @http = Net::HTTP.new(uri.host, uri.port)
-
-          unless options[:read_timeout].nil?
-            @http.read_timeout = options[:read_timeout]
-          end
-
           unless options[:pem_file].nil?
             pem = File.read(options[:pem_file])
             @http.use_ssl = true


### PR DESCRIPTION
Reverts FlickElectric/roar#2
